### PR TITLE
fix: sorting of articles fetched with GCP Datastore SDK - dates are J…

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -37,7 +37,7 @@ export const api = Router({strict: true, mergeParams: true, caseSensitive: true}
             .splice(0, articles.length, ...articles
                 .map(({slug, title, description, publishedAt, authors}) =>
                     ({slug, title, description, publishedAt, authors}))
-                .sort(({publishedAt: a}, {publishedAt: b}) => b.localeCompare(a)));
+                .sort(({publishedAt: a}, {publishedAt: b}) => +b-(+a)));
         res.json(success(articles, metadata));
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
fix: sorting of articles fetched with GCP Datastore SDK - dates are Javascript dates, not strings